### PR TITLE
Implemented a create-only function

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -26,7 +26,8 @@ type RequestContainer struct {
 // Container is the struct used to represent a single container.
 type Container struct {
 	// Container ID from Docker
-	ID string
+	ID      string
+	started bool
 	// Cache to retrieve container infromation without re-fetching them from dockerd
 	raw *types.ContainerJSON
 }
@@ -105,8 +106,48 @@ func (c *Container) GetHostEndpoint(ctx context.Context, port string) (string, s
 	return "", "", fmt.Errorf("port %s not found", port)
 }
 
-// RunContainer takes a RequestContainer as input and it runs a container via the docker sdk
-func RunContainer(ctx context.Context, containerImage string, input RequestContainer) (*Container, error) {
+// Run is the function that starts the container. It can executed once
+func (c *Container) Run(ctx context.Context, waitFor wait.WaitStrategy) error {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return err
+	}
+	if c.started == true {
+		return fmt.Errorf("you can start a container only one.")
+	}
+	if err := cli.ContainerStart(ctx, c.ID, types.ContainerStartOptions{}); err != nil {
+		return err
+	}
+	c.started = true
+
+	if err := waitFor.WaitUntilReady(ctx, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+// RunAndWait is the function that starts the container and it uses a waiting strategy. It can executed once
+func (c *Container) RunAndWait(ctx context.Context, waitFor wait.WaitStrategy) error {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return err
+	}
+	if c.started == true {
+		return fmt.Errorf("you can start a container only one.")
+	}
+	if err := cli.ContainerStart(ctx, c.ID, types.ContainerStartOptions{}); err != nil {
+		return err
+	}
+	c.started = true
+
+	if err := waitFor.WaitUntilReady(ctx, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CreateContainer takes a RequestContainer as input and it creates a container via the docker sdk
+func CreateContainer(ctx context.Context, containerImage string, input RequestContainer) (*Container, error) {
 	cli, err := client.NewEnvClient()
 	if err != nil {
 		return nil, err
@@ -156,18 +197,23 @@ func RunContainer(ctx context.Context, containerImage string, input RequestConta
 	if err != nil {
 		return nil, err
 	}
-	if err := cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
+	containerInstance := &Container{
+		ID:      resp.ID,
+		started: false,
+	}
+	return containerInstance, nil
+}
+
+// RunContainer takes a RequestContainer as input and it creates and runs a container via the docker sdk
+func RunContainer(ctx context.Context, containerImage string, input RequestContainer) (*Container, error) {
+	containerInstance, err := CreateContainer(ctx, containerImage, input)
+	if err != nil {
 		return nil, err
 	}
-	containerInstance := &Container{
-		ID: resp.ID,
-	}
-
-	// if a WaitStrategy has been specified, wait before returning
 	if input.WaitingFor != nil {
-		if err := input.WaitingFor.WaitUntilReady(ctx, containerInstance); err != nil {
-			// return containerInstance for termination
-			return containerInstance, err
+		err = containerInstance.RunAndWait(ctx, input.WaitingFor)
+		if err != nil {
+			return nil, err
 		}
 	}
 	return containerInstance, nil


### PR DESCRIPTION
As requested here #20 this PR implements a flow to only create
containers. The container has a new `Start` function to run it when you
wish.

@mraerino

```go
c, err := CreateContainer(ctx, "nginx", input)

....
....

err := c.Run(ctx)

.....
.....

```

Fixed #20

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>