### PR TITLE
Refactor docker handling to create client once for a context

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -28,12 +28,13 @@ type Container struct {
 	// Container ID from Docker
 	ID string
 	// Cache to retrieve container infromation without re-fetching them from dockerd
-	raw *types.ContainerJSON
+	raw    *types.ContainerJSON
+	client *client.Client
 }
 
 // LivenessCheckPorts returns the exposed ports for the container.
 func (c *Container) LivenessCheckPorts(ctx context.Context) (nat.PortSet, error) {
-	inspect, err := inspectContainer(ctx, c)
+	inspect, err := c.inspectContainer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -42,25 +43,16 @@ func (c *Container) LivenessCheckPorts(ctx context.Context) (nat.PortSet, error)
 
 // Terminate is used to kill the container. It is usally triggered by as defer function.
 func (c *Container) Terminate(ctx context.Context, t *testing.T) error {
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		t.Error(err)
-		return err
-	}
-	return cli.ContainerRemove(ctx, c.ID, types.ContainerRemoveOptions{
+	return c.client.ContainerRemove(ctx, c.ID, types.ContainerRemoveOptions{
 		Force: true,
 	})
 }
 
-func inspectContainer(ctx context.Context, c *Container) (*types.ContainerJSON, error) {
+func (c *Container) inspectContainer(ctx context.Context) (*types.ContainerJSON, error) {
 	if c.raw != nil {
 		return c.raw, nil
 	}
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		return nil, err
-	}
-	inspect, err := cli.ContainerInspect(ctx, c.ID)
+	inspect, err := c.client.ContainerInspect(ctx, c.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +62,7 @@ func inspectContainer(ctx context.Context, c *Container) (*types.ContainerJSON, 
 
 // GetIPAddress returns the ip address for the running container.
 func (c *Container) GetIPAddress(ctx context.Context) (string, error) {
-	inspect, err := inspectContainer(ctx, c)
+	inspect, err := c.inspectContainer(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -79,7 +71,7 @@ func (c *Container) GetIPAddress(ctx context.Context) (string, error) {
 
 // GetHostEndpoint returns the IP address and the port exposed on the host machine.
 func (c *Container) GetHostEndpoint(ctx context.Context, port string) (string, string, error) {
-	inspect, err := inspectContainer(ctx, c)
+	inspect, err := c.inspectContainer(ctx)
 	if err != nil {
 		return "", "", err
 	}
@@ -167,7 +159,8 @@ func RunContainer(ctx context.Context, containerImage string, input RequestConta
 		return nil, err
 	}
 	containerInstance := &Container{
-		ID: resp.ID,
+		ID:     resp.ID,
+		client: cli,
 	}
 
 	// if a WaitStrategy has been specified, wait before returning


### PR DESCRIPTION
This is a suggestion for improved handling of the docker client.
It seems reasonable to reuse the client.