### PR TITLE
Implemented function to create-only container

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -122,10 +122,11 @@ func TestContainerCreationTimesOut(t *testing.T) {
 		},
 		WaitingFor: wait.ForListeningPort().WithStartupTimeout(1 * time.Second),
 	})
+
 	if err == nil {
 		t.Error("Expected timeout")
-		nginxC.Terminate(ctx, t)
 	}
+	defer nginxC.Terminate(ctx, t)
 }
 
 func TestContainerRespondsWithHttp200ForIndex(t *testing.T) {


### PR DESCRIPTION
We need the ability to create a container without running it.
This PR introduced this feature with the method `CreateContainer`.
It works like the `RunContainer` but without executing the container
cmd.

You can run it as you wish with the function `container.Run(ctx)`.

The `Run(ctx)` function doesn't need a wait strategy. If you need one
you need to set it up by yourself programmatically.

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>