### PR TITLE
BC BREAk move to testcontainers-go

### DIFF
--- a/container.go
+++ b/container.go
@@ -1,11 +1,11 @@
-package testcontainer
+package testcontainers
 
 import (
 	"context"
 
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
-	"github.com/testcontainers/testcontainer-go/wait"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 // DeprecatedContainer shows methods that were supported before, but are now deprecated

--- a/docker.go
+++ b/docker.go
@@ -1,4 +1,4 @@
-package testcontainer
+package testcontainers
 
 import (
 	"context"
@@ -18,7 +18,7 @@ import (
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 
-	"github.com/testcontainers/testcontainer-go/wait"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 // Implement interfaces

--- a/docker_test.go
+++ b/docker_test.go
@@ -1,4 +1,4 @@
-package testcontainer
+package testcontainers
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/go-connections/nat"
-	"github.com/testcontainers/testcontainer-go/wait"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 func TestTwoContainersExposingTheSamePort(t *testing.T) {

--- a/generic.go
+++ b/generic.go
@@ -1,4 +1,4 @@
-package testcontainer
+package testcontainers
 
 import (
 	"context"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/testcontainers/testcontainer-go
+module github.com/testcontainers/testcontainers-go
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect

--- a/legacy.go
+++ b/legacy.go
@@ -1,11 +1,11 @@
-package testcontainer
+package testcontainers
 
 import (
 	"context"
 
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
-	"github.com/testcontainers/testcontainer-go/wait"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 var _ DeprecatedContainer = (*DockerContainer)(nil)

--- a/legacy_test.go
+++ b/legacy_test.go
@@ -1,4 +1,4 @@
-package testcontainer
+package testcontainers
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/go-connections/nat"
-	"github.com/testcontainers/testcontainer-go/wait"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 func TestLegacyTwoContainersExposingTheSamePort(t *testing.T) {

--- a/reaper.go
+++ b/reaper.go
@@ -1,4 +1,4 @@
-package testcontainer
+package testcontainers
 
 import (
 	"bufio"


### PR DESCRIPTION

The right name for the package should be testcontainers-go not
testcontainer-go. The `s` is important for consistency with the other
libraries across languages.

This is BC break and to fix this you need to change the import in your
applications.

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>